### PR TITLE
FiberClass.py name discrepancy and bug line 277

### DIFF
--- a/FiberPho_Main/FiberClass.py
+++ b/FiberPho_Main/FiberClass.py
@@ -274,7 +274,7 @@ class FiberObj:
         except:
             print('no isosbestic data found')
 
-        shortest_len = min(len(channels) for channels in data_dict.items())
+        shortest_list = min(len(channels) for channels in data_dict.values())
         for channel in data_dict:
             data_dict[channel] = data_dict[channel][:shortest_list-1]
         self.fpho_data_df = pd.DataFrame.from_dict(data_dict)
@@ -1487,7 +1487,7 @@ def alt_to_boris(beh_file, time_unit, beh_false, time_between_bouts):
 
         for i, v in enumerate(diffs):
             if v > (time_between_bouts / conversion_to_sec):
-                stops.concat((trimmed.iloc[i]['Time']
+                stops.extend((trimmed.iloc[i]['Time']
                               - beh_file.iloc[0]['Time']) * conversion_to_sec)
                 if i+1 < len(diffs):
                     starts.concat((trimmed.iloc[i+1]['Time']

--- a/FiberPho_Main/FiberClass.py
+++ b/FiberPho_Main/FiberClass.py
@@ -1487,7 +1487,7 @@ def alt_to_boris(beh_file, time_unit, beh_false, time_between_bouts):
 
         for i, v in enumerate(diffs):
             if v > (time_between_bouts / conversion_to_sec):
-                stops.extend((trimmed.iloc[i]['Time']
+                stops.concat((trimmed.iloc[i]['Time']
                               - beh_file.iloc[0]['Time']) * conversion_to_sec)
                 if i+1 < len(diffs):
                     starts.concat((trimmed.iloc[i+1]['Time']

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ param==1.12.0
 plotly==5.5.0
 scipy==1.7.2
 tornado==6.1
+kaleido==0.2.1


### PR DESCRIPTION
Hi, I fixed the problems relating to [issue #4](https://github.com/donaldsonlab/PhAT/issues/4). These errors made it so that data did not load when using the "alternative" file type. These were simple fixes so I forked the repository and changed them myself. Data now loads and plots appropriately. 

Accidentally made a change in line 1490 for a different error, so I changed that back to how it was and will create a new issue for it. 